### PR TITLE
bugfix: comments now can be shown in multiline

### DIFF
--- a/components/new-post/Comment.jsx
+++ b/components/new-post/Comment.jsx
@@ -52,7 +52,7 @@ const Comment = ({ comment, user, postId, queryClient }) => {
             {formatDistanceToNow(new Date(comment.date), { addSuffix: true })}
           </span>
         </h4>
-        <p className="text-sm">{comment.text}</p>
+        <p className="text-sm whitespace-pre-wrap">{comment.text}</p>
         {user && user._id === comment.user._id && (
           <TrashIcon
             onClick={() => mutation.mutate()}


### PR DESCRIPTION
- fix issue where comments are showing just in single line by adding `whitespace:pre-wrap` to paragraph style
closes #5 

# Comment
![image](https://user-images.githubusercontent.com/14231264/136558095-a91b9f36-c43f-48ec-8d2a-12170afb1560.png)

# Before
![image](https://user-images.githubusercontent.com/14231264/136557646-ad068077-0d1f-4d97-8bc8-30eefcf6402c.png)

# After
![image](https://user-images.githubusercontent.com/14231264/136558037-aaf973bd-a102-41aa-8f6b-c8449a62ccf8.png)
